### PR TITLE
Support version vector equality checks

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,4 @@
-from loro import LoroDoc, ExportMode
+from loro import LoroDoc, ExportMode, VersionVector
 
 def test_basic():
     doc = LoroDoc()
@@ -7,3 +7,17 @@ def test_basic():
     text.insert(0, "abc")
     doc.commit()
     assert text.to_string() == "abc"
+
+def test_version_vector():
+    doc1 = LoroDoc()
+    assert doc1.state_vv == VersionVector()
+    text = doc1.get_text("text")
+    text.insert(0, "abc")
+
+    snapshot = doc1.export({"mode": "snapshot"})
+    doc2 = LoroDoc()
+    assert doc1.state_vv != doc2.state_vv
+
+    doc2.import_(snapshot)
+    assert doc2.get_text("text").to_string() == "abc"
+    assert doc1.state_vv == doc2.state_vv


### PR DESCRIPTION
Fix for https://github.com/loro-dev/loro-py/issues/2

I only did == and != for now because I don't think it's possible to determine greater than / less than.