### PR TITLE
Reproduce error when accessing loro fields from a wrapper object

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,4 +1,18 @@
-from loro import LoroDoc, StyleConfigMap, TextDelta
+from loro import ExportMode, LoroDoc, LoroMap, LoroText, StyleConfigMap, TextDelta, ValueOrContainer
+
+class Wrapper:
+
+    def __init__(self, doc: LoroDoc):
+        self.doc = doc
+
+    @classmethod
+    def from_snapshot(cls, snapshot: bytes) -> 'Wrapper':
+        doc = LoroDoc()
+        doc.import_(snapshot)
+        return cls(doc)
+
+    def export(self) -> bytes:
+        return self.doc.export(ExportMode.Snapshot())
 
 
 def test_text_get_value():
@@ -36,3 +50,11 @@ def test_text_to_delta():
             assert isinstance(delta, TextDelta.Insert)
             assert delta.insert == " world!"
             assert delta.attributes == None
+
+def test_wrapper():
+    wrapper = Wrapper(LoroDoc())
+    text = LoroText()
+    text.insert(0, 'Hello world!')
+    wrapper.doc.get_map('fields').insert_container('text', text)
+
+    Wrapper.from_snapshot(wrapper.export()).doc.get_map('fields').get_deep_value()

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -57,4 +57,9 @@ def test_wrapper():
     text.insert(0, 'Hello world!')
     wrapper.doc.get_map('fields').insert_container('text', text)
 
+    # this works because wrapper is stored as a variable
+    wrapper_2 = Wrapper.from_snapshot(wrapper.export())
+    wrapper_2.doc.get_map('fields').get_deep_value()
+
+    # this fails
     Wrapper.from_snapshot(wrapper.export()).doc.get_map('fields').get_deep_value()


### PR DESCRIPTION
This adds a failing test case to reproduce the issue.

I think it's because we're not storing `Wrapper.from_snapshot(..)` to a variable so there is some memory issue happening within rust?