### PR TITLE
Implement __setitem__, __getitem__ and __delitem__

### DIFF
--- a/src/container/map.rs
+++ b/src/container/map.rs
@@ -17,7 +17,7 @@ pub fn register_class(m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-#[pyclass(frozen)]
+#[pyclass(frozen, mapping)]
 #[derive(Debug, Clone, Default)]
 pub struct LoroMap(pub LoroMapInner);
 
@@ -63,6 +63,30 @@ impl LoroMap {
     /// Get the length of the map.
     pub fn __len__(&self) -> usize {
         self.0.len()
+    }
+
+    pub fn __contains__(&self, key: &str) -> bool {
+        match self.0.get(key) {
+            Some(_) => true,
+            None => false
+        }
+    }
+
+    pub fn __getitem__(&self, key: &str) -> Option<ValueOrContainer> {
+        self.get(key)
+    }
+
+    pub fn __setitem__(&self, key: &str, value: LoroValue) -> PyLoroResult<()> {
+        self.insert(key, value)
+    }
+
+    pub fn __delitem__(&self, key: &str) -> PyLoroResult<()> {
+        self.0.delete(key)?;
+        Ok(())
+    }
+
+    pub fn __iter__(&self) -> Vec<String> {
+        self.0.keys().map(|k| k.to_string()).collect()
     }
 
     /// Get the ID of the map.

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -10,3 +10,5 @@ def test_map():
     assert doc.get_deep_value() == {
         "map": {"key": "value", "key2": ["value2"]},
     }
+    map["key2"] = "value2"
+    assert map["key2"].value == "value2"


### PR DESCRIPTION
The classes `loro.LoroMap`, `loro.LoroList` and `loro.LoroMovableList` indicate by name that they are Mappings resp. Sequences. However, some methods that are expected of python mappings/sequences are not implemented, especially __setitem__, __getitem__ and __delitem__, which allow to use syntax of the form `map["x"] = value`, `map["x"]` and `del map["x"]` (similar for the sequences). This commit implements these three methods, making the API a bit more pythonic.

Even with these methods implemented, the classes are not considered Mappings or Sequences by python, as indicated by `isinstance(loro.LoroMap(), collections.abc.Mapping)` and `isinstance(loro.LoroList(), collections.abc.Sequence)`. This requires at least implementing `__iter__`.

The python syntax `l[0:3]` calls `__getitem__` with a slice object, while `l[3]` calls `__getitem__` with an isize. To support both I introduced `SliceOrInt`. I wasn't quite sure where this struct should live, currently it is defined in both `list.rs` and `mutable_list.rs`, but I assume it should only be defined once.

The code currently also produces the warning ```type `list::SliceOrInt<'py>` is more private than the item `list::LoroList::__getitem__```.