### PR TITLE
Adopt PEP 639 license statement in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "loro"
 authors = [{ name = "leon7hao", email = "lz@loro.dev" }]
 description = "Python bindings for [Loro](https://loro.dev)"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = ["local-first", "CRDT", "loro"]
 requires-python = ">=3.8"
 classifiers = [


### PR DESCRIPTION
Hi,

thanks for the bindings 🙂 !

recently I scanned a virtual environment of mine and found that loro-py was the only package among 80 or so that showed up with license: UNKNOWN when running something like `$ pip-licenses --from=mixed --format=rst`.

I guess this is due to `license = { file = "LICENSE" }` being the only license info in pyproject.toml. The license file gets copied to the wheel, but no meta-information is provided.

I suggest to follow https://packaging.python.org/en/latest/specifications/pyproject-toml

-- Lukas